### PR TITLE
[COR-67] Add registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loke/http-rpc",
-  "version": "4.0.1",
+  "version": "5.0.0-beta",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Relates to: [COR-67]

Registers metrics for `requestDuration`, `requestCount` and `failureCount` in loke-hhtp-rpc

[COR-67]: https://loke.atlassian.net/browse/COR-67