### PR TITLE
Support multiple major versions of prom-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2210,7 +2210,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fastq": {
@@ -2326,7 +2326,7 @@
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "get-caller-file": {
@@ -2810,7 +2810,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "js-string-escape": {
@@ -2861,7 +2861,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "keyv": {
@@ -3135,7 +3135,7 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "negotiator": {
@@ -3515,9 +3515,9 @@
       }
     },
     "prom-client": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
-      "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.1.1.tgz",
+      "integrity": "sha512-hFU32q7UZQ59bVJQGUtm3I2PrJ3gWvoCkilX9sF165ks1qflhugVCeK+S1JjJYHvyt3o5kj68+q3bchormjnzw==",
       "dev": true,
       "requires": {
         "tdigest": "^0.1.1"
@@ -4073,7 +4073,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "time-zone": {

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "express": "^4.14.0",
     "got": "^11.6.2",
     "prettier": "2.1.1",
-    "prom-client": "^12.0.0",
+    "prom-client": "^14.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.2"
   },
   "peerDependencies": {
-    "prom-client": "12.x"
+    "prom-client": ">=12 <=14"
   },
   "dependencies": {
     "ajv": "^8.11.0"


### PR DESCRIPTION
We have different libraries with different prom-client peer deps. 

This will make it impossible to get working cleanly in node v18 as it errors without --force.

We have been using this with prom-client v14 for a while (in tidy-api).

```
npm ERR! code ERESOLVE
  | npm ERR! ERESOLVE could not resolve
  | npm ERR!
  | npm ERR! While resolving: @loke/http-rpc@5.1.0
  | npm ERR! Found: prom-client@14.0.1
  | npm ERR! node_modules/prom-client
  | npm ERR!   prom-client@"^14.0.1" from the root project
  | npm ERR!
  | npm ERR! Could not resolve dependency:
  | npm ERR! peer prom-client@"12.x" from @loke/http-rpc@5.1.0
  | npm ERR! node_modules/@loke/http-rpc
  | npm ERR!   @loke/http-rpc@"^5.1.0" from the root project
  | npm ERR!
  | npm ERR! Conflicting peer dependency: prom-client@12.0.0
  | npm ERR! node_modules/prom-client
  | npm ERR!   peer prom-client@"12.x" from @loke/http-rpc@5.1.0
  | npm ERR!   node_modules/@loke/http-rpc
  | npm ERR!     @loke/http-rpc@"^5.1.0" from the root project
  | npm ERR!
 ```