### PR TITLE
[ORD-3265] - export ContextMethods definition

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -25,7 +25,7 @@ export {
 export {
   serviceWithSchema,
   contextServiceWithSchema,
-  ContextServiceMeta,
+  ContextMethods,
   voidSchema,
   VoidSchema,
 } from "./schema";

--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,7 @@ export {
 export {
   serviceWithSchema,
   contextServiceWithSchema,
+  ContextServiceMeta,
   voidSchema,
   VoidSchema,
 } from "./schema";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loke/http-rpc",
-  "version": "5.6.1",
+  "version": "5.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loke/http-rpc",
-      "version": "5.6.1",
+      "version": "5.7.0",
       "dependencies": {
         "@loke/context": "^0.0.1",
         "ajv": "^8.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loke/http-rpc",
-  "version": "5.5.0",
+  "version": "5.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loke/http-rpc",
-      "version": "5.5.0",
+      "version": "5.6.1",
       "dependencies": {
         "@loke/context": "^0.0.1",
         "ajv": "^8.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loke/http-rpc",
-  "version": "5.7.0",
+  "version": "5.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loke/http-rpc",
-      "version": "5.7.0",
+      "version": "5.6.0",
       "dependencies": {
         "@loke/context": "^0.0.1",
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loke/http-rpc",
-  "version": "5.6.1",
+  "version": "5.7.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loke/http-rpc",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loke/http-rpc",
-  "version": "5.7.0",
+  "version": "5.6.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/schema.ts
+++ b/schema.ts
@@ -97,20 +97,25 @@ interface Logger {
   error: (str: string) => void;
 }
 
+export interface ContextServiceMeta<
+  S extends ContextService,
+  Def extends Record<string, unknown> = Record<string, never>,
+> {
+  name: string;
+  definitions?: {
+    [K in keyof Def]: JTDSchemaType<Def[K], Def>;
+  };
+  methods: ContextMethods<S, Def>;
+  logger: Logger;
+  strictResponseValidation?: boolean;
+}
+
 export function contextServiceWithSchema<
   S extends ContextService,
   Def extends Record<string, unknown> = Record<string, never>,
 >(
   service: S,
-  serviceMeta: {
-    name: string;
-    definitions?: {
-      [K in keyof Def]: JTDSchemaType<Def[K], Def>;
-    };
-    methods: ContextMethods<S, Def>;
-    logger: Logger;
-    strictResponseValidation?: boolean;
-  },
+  serviceMeta: ContextServiceMeta<S, Def>,
 ): ServiceSet<any> {
   const wrappedService: Service = {};
 

--- a/schema.ts
+++ b/schema.ts
@@ -82,7 +82,7 @@ type Methods<
   >;
 };
 
-type ContextMethods<
+export type ContextMethods<
   S extends ContextService,
   Def extends Record<string, unknown> = Record<string, never>,
 > = {
@@ -97,25 +97,20 @@ interface Logger {
   error: (str: string) => void;
 }
 
-export interface ContextServiceMeta<
-  S extends ContextService,
-  Def extends Record<string, unknown> = Record<string, never>,
-> {
-  name: string;
-  definitions?: {
-    [K in keyof Def]: JTDSchemaType<Def[K], Def>;
-  };
-  methods: ContextMethods<S, Def>;
-  logger: Logger;
-  strictResponseValidation?: boolean;
-}
-
 export function contextServiceWithSchema<
   S extends ContextService,
   Def extends Record<string, unknown> = Record<string, never>,
 >(
   service: S,
-  serviceMeta: ContextServiceMeta<S, Def>,
+  serviceMeta: {
+    name: string;
+    definitions?: {
+      [K in keyof Def]: JTDSchemaType<Def[K], Def>;
+    };
+    methods: ContextMethods<S, Def>;
+    logger: Logger;
+    strictResponseValidation?: boolean;
+  },
 ): ServiceSet<any> {
   const wrappedService: Service = {};
 


### PR DESCRIPTION
Internal Change Only

[ORD-3265]

- create a type for the ContextMethods parameter (part of serviceMeta) in contextServiceWithSchema and export it
- the type will be used in /ordering to define the serviceMeta (schema) for the ordering service rpc in the shared folder, but public-api, kounta, & zonal will implement the rpc service individually in their respective repos
  - this refactor eliminates the need for using the --install-links flag when running npm i / npm ci in those repos with the new context service (forcing them to use the same instance of @loke/http-rpc instead of local ones)

## Submitter Checklist

Check only those that apply to this change.

- [x] Self-reviewed code, removed extraneous comments, debug logging, checked code style
- [x] No change to users after merge (off-by-default configuration, feature flag, alt URL, etc.) and can be disabled if issues arise (if this is not the case we may need stakeholder signoff)
- [ ] Changes are documented (README, wiki, etc)
- [ ] Automated tests added or existing tests cover the new functionality or changes
- [ ] Manually tested changes
- [ ] Metrics added to track the usage/performance
- [x] I am confident I can revert this change
- [ ] Database migrations are reversible without data loss (if applicable)
- [ ] Performance impact is acceptable (if applicable)
- [ ] Any new dependencies are justified or have been approved (if applicable)
- [ ] **This is NOT a high risk change** (if it is, please follow the high-risk change process)

### Testing Evidence

What evidence supports that you have tested this change?

- [x] Test cases cover the new functionality or changes
- [ ] Screenshots or logs of the changes (if applicable)
- [ ] Performance benchmarks (if applicable)
- [ ] Storybook cases (if applicable)

## Reviewer Checklist

Note: if this PR affects authentication or payments please seek a secondary tester.

- [ ] I am ok with code style and functionality
- [ ] I have personally tested the feature
- [ ] My review was not rushed due to time constraints


[ORD-3265]: https://loke.atlassian.net/browse/ORD-3265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ