### PR TITLE
[ORD-3299] Add `strictRequestValidation` option for non-strict request validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm cit
+      - run: npm run lint
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run lint


### PR DESCRIPTION
Internal change only

## Summary

[ORD-3299]

Adds a new `strictRequestValidation` configuration option that allows services to log warnings for invalid requests instead of throwing errors. This mirrors the existing `strictResponseValidation` behavior and enables a more permissive validation mode when needed.

### Reasoning

One of the main reasons for not migrating old RPC services to use types is because it's really easy for those types to incorrect slightly or off a little bit due to javascript not being a typed language so some of our documented types are just wrong. This change will help with the migration process so then we still are informed about any issues with schema validation, but it won't completely break production

## Changes

### Core Implementation

- **Added `strictRequestValidation` parameter** to `serviceWithSchema()` and `contextServiceWithSchema()`
	- Type: `boolean`
	- Default: `true` (strict validation enabled by default)

- **Updated Logger interface** to require both `error()` and `warn()` methods

- **Modified request validation logic** in `schema.ts`:
	- When `strictRequestValidation: true` (default): Throws `ValidationError` on invalid requests
	- When `strictRequestValidation: false`: Logs validation errors as warnings via `logger.warn()` and continues processing

- **Updated response validation** to use `logger.warn()` when `strictResponseValidation: false`

## Submitter Checklist

Check only those that apply to this change.

- [x] Self-reviewed code, removed extraneous comments, debug logging, checked code style
- [x] No change to users after merge (off-by-default configuration, feature flag, alt URL, etc.) and can be disabled if issues arise (if this is not the case we may need stakeholder signoff)
- [ ] Changes are documented (README, wiki, etc)
- [x] Automated tests added or existing tests cover the new functionality or changes
- [ ] Manually tested changes
- [ ] Metrics added to track the usage/performance
- [x] I am confident I can revert this change
- [ ] Database migrations are reversible without data loss (if applicable)
- [ ] Performance impact is acceptable (if applicable)
- [ ] Any new dependencies are justified or have been approved (if applicable)
- [x] **This is NOT a high risk change** (if it is, please follow the high-risk change process)

### Testing Evidence

What evidence supports that you have tested this change?

- [x] Test cases cover the new functionality or changes
- [ ] Screenshots or logs of the changes (if applicable)
- [ ] Performance benchmarks (if applicable)
- [ ] Storybook cases (if applicable)

## Reviewer Checklist

Note: if this PR affects authentication or payments please seek a secondary tester.

- [ ] I am ok with code style and functionality
- [ ] I have personally tested the feature
- [ ] My review was not rushed due to time constraints


[ORD-3299]: https://loke.atlassian.net/browse/ORD-3299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ