### PR TITLE
[MID-157] Show received value in RPC validation errors

### DIFF
--- a/schema.ts
+++ b/schema.ts
@@ -230,7 +230,7 @@ export function serviceWithSchema<
           if (err) {
             params.instancePath = err.instancePath;
             params.schemaPath = err.schemaPath;
-            msg = errorMessage(err);
+            msg = errorMessage(err, args);
           }
         }
 
@@ -252,7 +252,7 @@ export function serviceWithSchema<
             if (err) {
               params.instancePath = err.instancePath;
               params.schemaPath = err.schemaPath;
-              msg = errorMessage(err);
+              msg = errorMessage(err, result);
             }
           }
 
@@ -278,13 +278,38 @@ export function serviceWithSchema<
 
 // errorMessage formats an error message from an AJV JTD error object
 // example
-//   { message : "should be string", instancePath : "/user/name" }
+//   { message : "must be string", instancePath : "/user/name" }
 // becomes
-//   "user.name should be string"
-function errorMessage(err: ErrorObject): string {
+//   "user.name must be string, received number"
+function errorMessage(err: ErrorObject, data?: unknown): string {
+  let received = "";
+  if (data !== undefined && err.instancePath) {
+    const parts = err.instancePath.slice(1).split("/");
+    let current: unknown = data;
+    for (const part of parts) {
+      if (current === null || typeof current !== "object") {
+        current = undefined;
+        break;
+      }
+      current = (current as Record<string, unknown>)[part];
+    }
+    if (current !== undefined) {
+      const t = Array.isArray(current)
+        ? "array"
+        : current === null
+          ? "null"
+          : typeof current;
+      // Show the actual value for non-string primitives (numbers, booleans).
+      // For strings, objects, and arrays only show the type to avoid logging PII.
+      const detail = t === "number" || t === "boolean" ? String(current) : t;
+      received = `, received ${detail}`;
+    }
+  }
   return (
     (err.instancePath
-      ? err.instancePath.slice(1).replace(/\//g, ".") + " "
-      : "") + err.message
+      ? `${err.instancePath.slice(1).replace(/\//g, ".")} `
+      : "") +
+    err.message +
+    received
   );
 }

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -203,12 +203,46 @@ test("should validate schemas", async (t) => {
     );
 
     t.deepEqual(JSON.parse(err.response.body as string), {
-      message: "user.name must be string",
+      message: "user.name must be string, received 1",
       code: "validation",
       type: "https://errors.loke.global/@loke/http-rpc/validation",
       instancePath: "/user/name",
       schemaPath: "/definitions/User/properties/name/type",
     });
+  }
+
+  // null leaf value should report received null
+  {
+    const err: HTTPError = await t.throwsAsync(() =>
+      got
+        .post(`${serverAddress}/rpc/service1/bar`, {
+          json: { message: "c", user: { name: null } },
+        })
+        .json(),
+    );
+
+    t.deepEqual(JSON.parse(err.response.body as string), {
+      message: "user.name must be string, received null",
+      code: "validation",
+      type: "https://errors.loke.global/@loke/http-rpc/validation",
+      instancePath: "/user/name",
+      schemaPath: "/definitions/User/properties/name/type",
+    });
+  }
+
+  // null parent object should report received null
+  {
+    const err: HTTPError = await t.throwsAsync(() =>
+      got
+        .post(`${serverAddress}/rpc/service1/bar`, {
+          json: { message: "c", user: null },
+        })
+        .json(),
+    );
+
+    const body = JSON.parse(err.response.body as string);
+    t.is(body.code, "validation");
+    t.regex(body.message, /received null/);
   }
 
   // Methods with invalid void should fail


### PR DESCRIPTION
Internal change only

[MID-157]

- Validation error messages now include the received value alongside the expected type constraint
- e.g. `amountDetails.line_items.5.tax.total_tax_amount must be uint32 (got -150)` instead of just `amountDetails.line_items.5.tax.total_tax_amount must be uint32`
- Applies to both request and response validation errors

### Behaviour Mapping

```sh
- must be uint32 + got -150 --> received -150
- must be string + got 1 --> received 1
- must be string + got null --> received null
- must be number + got string --> received string
- must be object + got [] --> received array
```

NOTE: strings not showing received values was a deliberate decision to remain PII compliant

## Screenshots / Videos

<img width="2263" height="689" alt="image" src="https://github.com/user-attachments/assets/bbc19eb6-6c8a-484f-b4b6-a98fb4543231" />

##  I have:
- [x] Run and tested the code and provided clear evidence of this above
- [x] Self reviewed the code and removed extraneous comments, debug logging, checked code style
- [x] Listed any dependant PRs required for this change
- [x] Added tests where practical and possible
- [x] Documented a way to roll this change back if it is more than a code revert

_all the above **must** be ticked_


[MID-157]: https://loke.atlassian.net/browse/MID-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ