### PR TITLE
Interface and class as type params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loke/http-rpc",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/schema.ts
+++ b/schema.ts
@@ -6,10 +6,11 @@ import Ajv, {
 import {
   ServiceSet,
   Service,
-  ContextService,
+  ContextMethod,
   ServiceDetails,
   requestContexts,
   UnionSchemaType,
+  Method,
 } from "./common";
 
 interface ValidationErrorParams {
@@ -17,7 +18,9 @@ interface ValidationErrorParams {
   schemaPath?: string;
 }
 
-export const voidSchema = { metadata: { void: true } } as const;
+export const voidSchema: { readonly metadata: { readonly void: true } } = {
+  metadata: { void: true },
+};
 
 export type VoidSchema = typeof voidSchema;
 
@@ -72,82 +75,107 @@ export interface MethodDetails<
   responseTypeDef?: JTDSchemaType<Res, Def> | VoidSchema;
 }
 
+type ServiceMethodKeys<S> = {
+  [K in keyof S]-?: NonNullable<S[K]> extends Method ? K : never;
+}[keyof S];
+
+type ContextMethodKeys<S> = {
+  [K in keyof S]-?: NonNullable<S[K]> extends ContextMethod ? K : never;
+}[keyof S];
+
+type ServiceMethod<S, K extends keyof S> =
+  NonNullable<S[K]> extends Method ? NonNullable<S[K]> : never;
+
+type ContextServiceMethod<S, K extends keyof S> =
+  NonNullable<S[K]> extends ContextMethod ? NonNullable<S[K]> : never;
+
 type Methods<
-  S extends Service,
+  S extends object,
   Def extends Record<string, unknown> = Record<string, never>,
 > = {
-  [K in keyof S]?: MethodDetails<
-    Parameters<S[K]>[0],
-    Awaited<ReturnType<S[K]>>,
+  [K in ServiceMethodKeys<S>]?: MethodDetails<
+    Parameters<ServiceMethod<S, K>>[0],
+    Awaited<ReturnType<ServiceMethod<S, K>>>,
     Def
   >;
 };
 
 export type ContextMethods<
-  S extends ContextService,
+  S extends object,
   Def extends Record<string, unknown> = Record<string, never>,
 > = {
-  [K in keyof S]?: MethodDetails<
-    Parameters<S[K]>[1],
-    Awaited<ReturnType<S[K]>>,
+  [K in ContextMethodKeys<S>]?: MethodDetails<
+    Parameters<ContextServiceMethod<S, K>>[1],
+    Awaited<ReturnType<ContextServiceMethod<S, K>>>,
     Def
   >;
+};
+
+type RuntimeMethods<Def extends Record<string, unknown>> = {
+  [K in string]?: MethodDetails<unknown, unknown, Def>;
 };
 
 interface Logger {
   error: (str: string) => void;
 }
 
-export function contextServiceWithSchema<
-  S extends ContextService,
-  Def extends Record<string, unknown> = Record<string, never>,
->(
-  service: S,
-  serviceMeta: {
-    name: string;
-    definitions?: {
-      [K in keyof Def]:
-        | JTDSchemaType<Def[K], Def>
-        | UnionSchemaType<Def[K], Def>;
-    };
-    methods: ContextMethods<S, Def>;
-    logger: Logger;
-    strictResponseValidation?: boolean;
-  },
-): ServiceSet<any> {
-  const wrappedService: Service = {};
+interface ServiceMeta<
+  Def extends Record<string, unknown>,
+  M extends RuntimeMethods<Def>,
+> {
+  name: string;
+  definitions?: {
+    [K in keyof Def]: JTDSchemaType<Def[K], Def> | UnionSchemaType<Def[K], Def>;
+  };
+  methods: M;
+  logger: Logger;
+  strictResponseValidation?: boolean;
+}
 
-  for (const methodName of Object.keys(serviceMeta.methods)) {
-    wrappedService[methodName] = async (args: unknown) => {
-      const ctx = requestContexts.get(args as object);
+export function contextServiceWithSchema<
+  S extends object,
+  Def extends Record<string, unknown> = Record<string, never>,
+  M extends ContextMethods<S, Def> = ContextMethods<S, Def>,
+>(
+  service: S & { [K in keyof M]-?: ContextMethod },
+  serviceMeta: ServiceMeta<Def, M>,
+): ServiceSet<Service> {
+  return createServiceWithSchema(serviceMeta, (methodName) => {
+    return async (args: unknown) => {
+      if (typeof args !== "object" || args === null) {
+        throw new Error("missing request context");
+      }
+
+      const ctx = requestContexts.get(args);
       if (!ctx) {
         throw new Error("missing request context");
       }
 
       return await service[methodName](ctx, args);
     };
-  }
-
-  return serviceWithSchema(wrappedService, serviceMeta);
+  });
 }
 
 export function serviceWithSchema<
-  S extends Service,
+  S extends object,
   Def extends Record<string, unknown> = Record<string, never>,
+  M extends Methods<S, Def> = Methods<S, Def>,
 >(
-  service: S,
-  serviceMeta: {
-    name: string;
-    definitions?: {
-      [K in keyof Def]:
-        | JTDSchemaType<Def[K], Def>
-        | UnionSchemaType<Def[K], Def>;
-    };
-    methods: Methods<S, Def>;
-    logger: Logger;
-    strictResponseValidation?: boolean;
-  },
-): ServiceSet<any> {
+  service: S & { [K in keyof M]-?: Method },
+  serviceMeta: ServiceMeta<Def, M>,
+): ServiceSet<Service> {
+  return createServiceWithSchema(serviceMeta, (methodName) =>
+    service[methodName].bind(service),
+  );
+}
+
+function createServiceWithSchema<
+  Def extends Record<string, unknown>,
+  M extends RuntimeMethods<Def>,
+>(
+  serviceMeta: ServiceMeta<Def, M>,
+  getEndpoint: (methodName: keyof M & string) => Method,
+): ServiceSet<Service> {
   const ajv = new Ajv({
     keywords: [
       {
@@ -162,7 +190,7 @@ export function serviceWithSchema<
     [methodName: string]: (args: unknown) => Promise<unknown>;
   } = {};
 
-  const serviceDetails: ServiceDetails<S, Def> = {
+  const serviceDetails: ServiceDetails<Service, Def> = {
     service: serviceMeta.name,
     definitions: serviceMeta.definitions,
     expose: [],
@@ -173,10 +201,12 @@ export function serviceWithSchema<
     strictResponseValidation = process.env.NODE_ENV !== "production",
   } = serviceMeta;
 
-  const methods: [string, MethodDetails<unknown, unknown, Def>][] =
-    Object.entries(serviceMeta.methods);
+  for (const methodName in serviceMeta.methods) {
+    const methodMeta = serviceMeta.methods[methodName];
+    if (!methodMeta) {
+      continue;
+    }
 
-  for (const [methodName, methodMeta] of methods) {
     let requestSchema: ValidateFunction;
     try {
       requestSchema = ajv.compile({
@@ -191,9 +221,11 @@ export function serviceWithSchema<
 
         ...methodMeta.requestTypeDef,
       });
-    } catch (err: any) {
+    } catch (err) {
       throw new Error(
-        `failed to compile "${methodName}" request schema: ${err.message}`,
+        `failed to compile "${methodName}" request schema: ${errorDescription(
+          err,
+        )}`,
       );
     }
 
@@ -203,9 +235,11 @@ export function serviceWithSchema<
         definitions: serviceMeta.definitions,
         ...methodMeta.responseTypeDef,
       });
-    } catch (err: any) {
+    } catch (err) {
       throw new Error(
-        `failed to compile "${methodName}" response schema: ${err.message}`,
+        `failed to compile "${methodName}" response schema: ${errorDescription(
+          err,
+        )}`,
       );
     }
 
@@ -217,7 +251,7 @@ export function serviceWithSchema<
       responseTypeDef: methodMeta.responseTypeDef,
     });
 
-    const endpoint = service[methodName].bind(service);
+    const endpoint = getEndpoint(methodName);
 
     implementation[methodName] = async (args: unknown) => {
       if (!requestSchema(args)) {
@@ -276,6 +310,10 @@ export function serviceWithSchema<
   };
 }
 
+function errorDescription(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 // errorMessage formats an error message from an AJV JTD error object
 // example
 //   { message : "must be string", instancePath : "/user/name" }
@@ -291,7 +329,7 @@ function errorMessage(err: ErrorObject, data?: unknown): string {
         current = undefined;
         break;
       }
-      current = (current as Record<string, unknown>)[part];
+      current = Reflect.get(current, part);
     }
     if (current !== undefined) {
       const t = Array.isArray(current)

--- a/schema.ts
+++ b/schema.ts
@@ -201,8 +201,7 @@ function createServiceWithSchema<
     strictResponseValidation = process.env.NODE_ENV !== "production",
   } = serviceMeta;
 
-  for (const methodName in serviceMeta.methods) {
-    const methodMeta = serviceMeta.methods[methodName];
+  for (const [methodName, methodMeta] of Object.entries(serviceMeta.methods)) {
     if (!methodMeta) {
       continue;
     }

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -35,6 +35,115 @@ function createServerAddress(app: Express, t: ExecutionContext) {
   return `http://localhost:${address.port}`;
 }
 
+test("schema helpers accept interface and class service types", (t) => {
+  interface SchemaHelperLocation {
+    name: string;
+  }
+
+  type SchemaHelperDefs = { SchemaHelperLocation: SchemaHelperLocation };
+
+  interface InterfaceLocationsService {
+    getLocation(args: { id: string }): Promise<SchemaHelperLocation>;
+  }
+
+  const interfaceService: InterfaceLocationsService = {
+    async getLocation(args) {
+      return { name: args.id };
+    },
+  };
+
+  class ClassLocationsService {
+    async getLocation(args: { id: string }): Promise<SchemaHelperLocation> {
+      return { name: args.id };
+    }
+  }
+
+  class ContextLocationsService {
+    async getLocation(
+      ctx: Context,
+      args: { id: string },
+    ): Promise<SchemaHelperLocation> {
+      context.getRequestId(ctx);
+      return { name: args.id };
+    }
+  }
+
+  const interfaceServiceSet = serviceWithSchema<
+    InterfaceLocationsService,
+    SchemaHelperDefs
+  >(interfaceService, {
+    name: "interfaceLocations",
+    methods: {
+      getLocation: {
+        requestTypeDef: {
+          properties: {
+            id: { type: "string" },
+          },
+        },
+        responseTypeDef: {
+          properties: {
+            name: { type: "string" },
+          },
+        },
+      },
+    },
+    logger: { error: t.log },
+  });
+
+  const classServiceSet = serviceWithSchema<
+    ClassLocationsService,
+    SchemaHelperDefs
+  >(new ClassLocationsService(), {
+    name: "classLocations",
+    methods: {
+      getLocation: {
+        requestTypeDef: {
+          properties: {
+            id: { type: "string" },
+          },
+        },
+        responseTypeDef: {
+          properties: {
+            name: { type: "string" },
+          },
+        },
+      },
+    },
+    logger: { error: t.log },
+  });
+
+  const contextClassServiceSet = contextServiceWithSchema<
+    ContextLocationsService,
+    SchemaHelperDefs
+  >(new ContextLocationsService(), {
+    name: "contextClassLocations",
+    methods: {
+      getLocation: {
+        requestTypeDef: {
+          properties: {
+            id: { type: "string" },
+          },
+        },
+        responseTypeDef: {
+          properties: {
+            name: { type: "string" },
+          },
+        },
+      },
+    },
+    logger: { error: t.log },
+  });
+
+  t.deepEqual(
+    [
+      interfaceServiceSet.meta.expose[0].methodName,
+      classServiceSet.meta.expose[0].methodName,
+      contextClassServiceSet.meta.expose[0].methodName,
+    ],
+    ["getLocation", "getLocation", "getLocation"],
+  );
+});
+
 test("should validate schemas", async (t) => {
   const app = express();
 

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -68,25 +68,17 @@ test("schema helpers accept interface and class service types", (t) => {
     }
   }
 
+  const getLocationSchema = {
+    requestTypeDef: { properties: { id: { type: "string" } } },
+    responseTypeDef: { properties: { name: { type: "string" } } },
+  } as const;
+
   const interfaceServiceSet = serviceWithSchema<
     InterfaceLocationsService,
     SchemaHelperDefs
   >(interfaceService, {
     name: "interfaceLocations",
-    methods: {
-      getLocation: {
-        requestTypeDef: {
-          properties: {
-            id: { type: "string" },
-          },
-        },
-        responseTypeDef: {
-          properties: {
-            name: { type: "string" },
-          },
-        },
-      },
-    },
+    methods: { getLocation: getLocationSchema },
     logger: { error: t.log },
   });
 
@@ -95,20 +87,7 @@ test("schema helpers accept interface and class service types", (t) => {
     SchemaHelperDefs
   >(new ClassLocationsService(), {
     name: "classLocations",
-    methods: {
-      getLocation: {
-        requestTypeDef: {
-          properties: {
-            id: { type: "string" },
-          },
-        },
-        responseTypeDef: {
-          properties: {
-            name: { type: "string" },
-          },
-        },
-      },
-    },
+    methods: { getLocation: getLocationSchema },
     logger: { error: t.log },
   });
 
@@ -117,20 +96,7 @@ test("schema helpers accept interface and class service types", (t) => {
     SchemaHelperDefs
   >(new ContextLocationsService(), {
     name: "contextClassLocations",
-    methods: {
-      getLocation: {
-        requestTypeDef: {
-          properties: {
-            id: { type: "string" },
-          },
-        },
-        responseTypeDef: {
-          properties: {
-            name: { type: "string" },
-          },
-        },
-      },
-    },
+    methods: { getLocation: getLocationSchema },
     logger: { error: t.log },
   });
 


### PR DESCRIPTION
Internal change only

Does some typescript BS that will allow us to pass in classes and `interface`s into the `serviceWithSchema` and `contextServiceWithSchema` methods.

<!--
## Related PRs
- https://github.com/LOKE/example/pull/1
-->

<!--
## Rollback Instructions

-->

## Screenshots / Videos

| Before | After |
|--------|--------|
| <img width="1129" height="195" alt="image" src="https://github.com/user-attachments/assets/ef8c2700-2971-40b3-b66d-760454571e1a" /> | <img width="886" height="137" alt="image" src="https://github.com/user-attachments/assets/3695a9a6-585f-416d-82a4-6f2722aadbfc" /> | 

##  I have:
- [x] Run and tested the code and provided clear evidence of this above
- [x] Self reviewed the code and removed extraneous comments, debug logging, checked code style
- [x] Listed any dependant PRs required for this change
- [x] Added tests where practical and possible
- [x] Documented a way to roll this change back if it is more than a code revert

_all the above **must** be ticked_
