### PR TITLE
Fix unlisted peerdep issue

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,16 +1,46 @@
 import { Histogram, Counter } from "prom-client";
-import { RequestHandler, ErrorRequestHandler } from "express";
 import { Abortable } from "@loke/context";
 import * as context from "@loke/context";
 import onFinished from "on-finished";
 import { randomBytes } from "crypto";
-
 import {
   ServiceSet,
   ServiceDetails,
   MethodDetails,
   requestContexts,
 } from "./common";
+
+// These types are shaped to be backwards compatible with Express — existing
+// users can pass our handlers directly to app.use() without type errors.
+// They can be made stricter in the next major version.
+interface RpcRequest {
+  method?: string;
+  headers: Record<string, string | string[] | undefined>;
+  path: string;
+  body: object;
+  on(event: "close", listener: () => void): void;
+}
+
+interface RpcResponse {
+  headersSent: boolean;
+  json(body: unknown): void;
+  status(code: number): this;
+}
+
+type NextFunction = (err?: unknown) => void;
+
+export type RequestHandler = (
+  req: RpcRequest,
+  res: RpcResponse,
+  next: NextFunction,
+) => void | Promise<void>;
+
+export type ErrorRequestHandler = (
+  err: any,
+  req: RpcRequest,
+  res: RpcResponse,
+  next: NextFunction,
+) => void;
 
 export {
   ServiceSet,
@@ -261,7 +291,6 @@ export function createErrorHandler(
       res.status(500).json({ message: err.message });
       return;
     }
-
     log(`Error executing ${source}: ${err.inner.stack}`);
 
     if (!err.inner.type) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loke/http-rpc",
-  "version": "5.10.0",
+  "version": "5.10.1",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/test/node-http.ts
+++ b/test/node-http.ts
@@ -1,0 +1,77 @@
+import test, { ExecutionContext } from "ava";
+import http from "http";
+import got from "got";
+import { createRequestHandler, ServiceDetails } from "../";
+
+function createServerAddress(
+  handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+  t: ExecutionContext,
+) {
+  const server = http.createServer(handler);
+  server.listen(0);
+  const address = server.address();
+  if (!address || typeof address !== "object") {
+    throw new Error("No server address found");
+  }
+  t.teardown(() => server.close());
+  return `http://localhost:${address.port}`;
+}
+
+function adapt(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  rawBody: string,
+) {
+  const path = new URL(req.url ?? "/", "http://localhost").pathname;
+  const body = rawBody ? (JSON.parse(rawBody) as object) : {};
+
+  const rpcReq = Object.assign(req, { path, body });
+
+  const rpcRes = {
+    get headersSent() {
+      return res.headersSent;
+    },
+    json(data: unknown) {
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify(data));
+    },
+    status(code: number) {
+      res.statusCode = code;
+      return this;
+    },
+  };
+
+  return { rpcReq, rpcRes };
+}
+
+test("works with plain node:http without express", async (t) => {
+  const implementation = {
+    hello: (x: { msg: string }) => `success ${x.msg}`,
+  };
+  const meta: ServiceDetails<typeof implementation> = {
+    expose: [{ methodName: "hello" }],
+    service: "hello-service",
+  };
+
+  const rpcHandler = createRequestHandler([{ implementation, meta }]);
+
+  const serverAddress = createServerAddress((req, res) => {
+    let rawBody = "";
+    req.on("data", (chunk: Buffer) => {
+      rawBody += chunk.toString();
+    });
+    req.on("end", () => {
+      const { rpcReq, rpcRes } = adapt(req, res, rawBody);
+      void rpcHandler(rpcReq, rpcRes, () => {
+        res.statusCode = 404;
+        res.end();
+      });
+    });
+  }, t);
+
+  const body = await got
+    .post(`${serverAddress}/hello-service/hello`, { json: { msg: "world" } })
+    .json();
+
+  t.is(body, "success world");
+});


### PR DESCRIPTION
Internal change only

`express` was an unlisted peer dependency — consuming projects needed it installed, but it wasn't declared anywhere. This caused type errors and missing-module failures in non-Express setups.

**Changes:**
- Removed `import { RequestHandler, ErrorRequestHandler } from "express"` from the library's public API
- Replaced them with local structural types (`RpcRequest`, `RpcResponse`, `NextFunction`, `RequestHandler`, `ErrorRequestHandler`) that are intentionally shaped to remain backward compatible with Express — existing `app.use(handler)` call sites continue to work without any changes
- Added `test/node-http.ts` to validate that the library works with plain `node:http` without Express

No runtime behaviour changed. Express users are unaffected.

<!--
## Related PRs
- https://github.com/LOKE/example/pull/1
-->

<!--
## Rollback Instructions

-->

## Screenshots / Videos

<img width="1273" height="191" alt="image" src="https://github.com/user-attachments/assets/4b77b969-7a58-402a-b48a-6bcf14c0ed4f" />
<img width="770" height="186" alt="image" src="https://github.com/user-attachments/assets/882b2dae-515c-4dc3-921f-406577c167e8" />

*This was tested by putting this new version into both tidy and aston (arguably our biggest / most complex apps) to confirm that without any code change except the version bump that everything would still compile successfully

##  I have:
- [x] Run and tested the code and provided clear evidence of this above
- [x] Self reviewed the code and removed extraneous comments, debug logging, checked code style
- [x] Listed any dependant PRs required for this change
- [x] Added tests where practical and possible
- [x] Documented a way to roll this change back if it is more than a code revert

_all the above **must** be ticked_
